### PR TITLE
Dont limit user to a forced version of certain build tools

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
      - make.inc.openblas-add-toolchain-overrides.patch
 
 build:
-  number: 2
+  number: 3
   string: cuda{{ cudatoolkit | replace(".*", "") }}_{{ PKG_BUILDNUM }} 
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake {{ cmake }}
-    - make {{ make }}  
+    - make
   host:
     - openblas {{ openblas }}
   run:


### PR DESCRIPTION
User shouldnt be forced to have specific version of some general tools (e.g. make), if we are not truly using version-specific features. We arent requiring this consistently across many feedstocks.